### PR TITLE
Refactor rust setup for Emacs 30

### DIFF
--- a/lisp/vutr-rust.el
+++ b/lisp/vutr-rust.el
@@ -3,15 +3,26 @@
 ;;; for Rust
 ;;; Code:
 
+(eval-when-compile
+  (require 'use-package))
+
+(defun vutr-rust--maybe-disable-flycheck ()
+  "Disable `flycheck-mode' when using `eglot'."
+  (when (bound-and-true-p eglot--managed-mode)
+    (flycheck-mode -1)))
+
 (use-package rustic
   :ensure t
+  :hook (rustic-mode . (lambda ()
+                         (eglot-ensure)
+                         (vutr-rust--maybe-disable-flycheck)))
   :init
   (setq rustic-lsp-client 'eglot)
   :bind (:map rustic-mode-map
-              ("C-c C-c l" . flycheck-list-errors))
+              ("C-c C-c l" . flymake-show-project-diagnostics))
   :config
-  (setq rustic-format-on-save t)
-  (setq rustic-rustfmt-args "+nightly")
+  (setq rustic-format-on-save t
+        rustic-rustfmt-args "+nightly")
   (setenv "RUST_LOG" "info"))
 
 


### PR DESCRIPTION
## Summary
- ensure Eglot integration for rustic and disable Flycheck when active
- bind diagnostics to Flymake display for Emacs 30 compatibility

## Testing
- `emacs -Q --batch -f batch-byte-compile lisp/vutr-rust.el` *(failed: Failed to download ‘gnu’ archive)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8b2ed6208332880437d9349e134f